### PR TITLE
update the phpunit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.3",
-        "phpunit/phpunit": "^4.8"
+        "guzzlehttp/guzzle": "^6.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
DGCGroup/MonCash-PHP-SDK dev-master requires phpunit/phpunit ^4.8 -> found phpunit/phpunit[4.8.0, ..., 4.8.36] but it conflicts with your root composer.json require (^9.5)